### PR TITLE
fix: return error when kustomize build fails

### DIFF
--- a/pkg/validation/components.go
+++ b/pkg/validation/components.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"io/fs"
 	"path/filepath"
 
@@ -30,12 +31,12 @@ func CheckComponents(logger Logger, afs afero.Afero, baseDir string, components 
 			// look for a Kustomization file in the directory
 			if kp, found := lookupKustomizationFile(logger, afs, path); found {
 				if err := checkKustomizeResources(logger, afs, kp); err != nil {
-					logger.Error("invalid resources", "path", path, "err", err)
+					return fmt.Errorf("invalid resources at %s: %w", path, err)
 				}
 				if d.Name() != "base" {
 					logger.Debug("checking Kustomization build ", "path", path)
 					if err := checkBuild(logger, fsys, path); err != nil {
-						logger.Error("invalid resources", "path", path, "err", err)
+						return fmt.Errorf("invalid resources at %s: %w", path, err)
 					}
 				}
 			}

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -1,7 +1,6 @@
 package validation_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -54,16 +53,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1`)
 			err = validation.CheckComponents(logger, afs, "/path/to", "components")
 
 			// then
-			require.NoError(t, err)
-			assert.Equal(t, []LogRecord{
-				{
-					Msg: "invalid resources",
-					KeyVals: []any{
-						"path", "/path/to/components",
-						"err", fmt.Errorf("kustomization.yaml is empty"),
-					},
-				},
-			}, logger.Errors())
+			require.Error(t, err, "invalid resources at /path/to/components: kustomization.yaml is empty")
+			assert.Empty(t, logger.Errors())
 			assert.Empty(t, logger.Warnings())
 		})
 
@@ -328,16 +319,8 @@ data:
 			err = validation.CheckComponents(logger, afs, "/path/to", "components")
 
 			// then
-			require.NoError(t, err)
-			assert.Equal(t, []LogRecord{
-				{
-					Msg: "invalid resources",
-					KeyVals: []any{
-						"path", "/path/to/components",
-						"err", fmt.Errorf("kustomization.yaml is empty"),
-					},
-				},
-			}, logger.Errors())
+			require.Error(t, err, "invalid resources at /path/to/components: kustomization.yaml is empty")
+			assert.Empty(t, logger.Errors())
 			assert.Contains(t, logger.Warnings(), LogRecord{
 				Msg: "resource is not referenced",
 				KeyVals: []interface{}{


### PR DESCRIPTION
needed for the Github action to fail when the config is invalid

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
