### PR TITLE
refactor(cmd): add a 'root' command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder /usr/src/app/check-argocd /usr/local/bin/
 # Run as non-root user
 USER 1001
 
-ENTRYPOINT ["/usr/local/bin/check-argocd"]
+ENTRYPOINT ["/usr/local/bin/check-argocd", "check"]

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -12,14 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := NewCheckCmd().Execute(); err != nil {
-		os.Exit(1)
-	}
-}
-
 // checkCmd represents the base command when called without any subcommands
 func NewCheckCmd() *cobra.Command {
 
@@ -28,7 +20,7 @@ func NewCheckCmd() *cobra.Command {
 	var verbose bool
 
 	checkCmd := &cobra.Command{
-		Use:   "argocd-checker --base-dir=$(pwd) --apps apps-of-apps,apps --components components --verbose=false",
+		Use:   "check --base-dir=$(pwd) --apps apps-of-apps,apps --components components --verbose=false",
 		Short: "Checks the Argo CD configuration",
 		Args:  cobra.ExactArgs(0),
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use: "argocd-checker",
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+var kubeconfig string
+var verbose bool
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (default to $KUBECONFIG or $HOME/.kube/config)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+	rootCmd.PersistentFlags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	rootCmd.AddCommand(NewCheckCmd())
+}


### PR DESCRIPTION
make a subcommand to check the configuration, hence leaving room for other upcoming commands

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
