### PR TITLE
fix(cmd): fail when resource file is not referenced

### DIFF
--- a/pkg/validation/resources.go
+++ b/pkg/validation/resources.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -85,7 +86,7 @@ entries:
 				continue entries
 			}
 		}
-		logger.Warn("resource is not referenced", "path", path, "resource", e.Name())
+		return fmt.Errorf("resource is not referenced: %s", filepath.Join(path, e.Name()))
 	}
 	return nil
 }


### PR DESCRIPTION
a warning message is not enough, the GH action would succeed and we would miss the problem

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
